### PR TITLE
add support for CPHP_TOKEN env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ require 'vendor/autoload.php';
 
 $service = Continuous\Sdk\Service::factory(['token' => 'my-access-token']);
 ```
+Another way to use your access token consist in declaring it in `CPHP_TOKEN` environment variable
 
 ### Get your repository list
 ```php

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
   "require-dev": {
     "phpunit/phpunit": "^4.6",
     "squizlabs/php_codesniffer": "^2.3",
-    "behat/behat": "^3.0"
+    "behat/behat": "^3.0",
+    "php-mock/php-mock-phpunit": "^1.1"
   },
   "require": {
     "php": ">=5.4.0",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
-<ruleset name="continuousphp-phing-tasks">
+<ruleset name="continuousphp-sdk">
     <description>PSR2 Coding standard</description>
     <rule ref="PSR2"/>
+    <file>src</file>
+    <file>tests</file>
 </ruleset>

--- a/src/Service.php
+++ b/src/Service.php
@@ -74,6 +74,8 @@ class Service
         
         if (isset($config['token'])) {
             $args['defaults']['headers']['Authorization'] = "Bearer " . $config['token'];
+        } elseif ($token = getenv('CPHP_TOKEN')) {
+            $args['defaults']['headers']['Authorization'] = "Bearer " . $token;
         }
         
         return new $className($args);

--- a/tests/ServiceTest.php
+++ b/tests/ServiceTest.php
@@ -12,6 +12,7 @@
 namespace Continuous\Tests\Sdk;
 
 use Continuous\Sdk\Service;
+use phpmock\phpunit\PHPMock;
 
 /**
  * ServiceTest
@@ -22,6 +23,8 @@ use Continuous\Sdk\Service;
  */
 class ServiceTest extends \PHPUnit_Framework_TestCase
 {
+    use PHPMock;
+    
     protected $httpClientMock;
     protected $originalHttpClientClass;
     protected $descriptionMock;
@@ -70,6 +73,23 @@ class ServiceTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("Bearer " . $token, $client->getDefaultOption('headers')['Authorization']);
     }
     
+    public function testGetHttpClientSetCorrectlyAccessTokenIfSetAsEnvVar()
+    {
+        $token = 'my-awesome-token';
+        $getenv = $this->getFunctionMock('Continuous\Sdk', 'getenv');
+        $getenv->expects($this->once())
+            ->with('CPHP_TOKEN')
+            ->willReturn($token);
+        
+        Service::setHttpClientClass('GuzzleHttp\Client');
+        
+        $client = Service::getHttpClient();
+        $this->assertInstanceOf('GuzzleHttp\Client', $client);
+        
+        $this->assertArrayHasKey('Authorization', $client->getDefaultOption('headers'));
+        $this->assertEquals("Bearer " . $token, $client->getDefaultOption('headers')['Authorization']);
+    }
+    
     public function testGetHttpClientHasNoTokenIfNotProvided()
     {
         Service::setHttpClientClass('GuzzleHttp\Client');
@@ -100,5 +120,4 @@ class ServiceTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertInstanceOf(Service::getDescriptionClass(), Service::getDescription());
     }
-    
 }


### PR DESCRIPTION
Uses CPHP_TOKEN env variable if available and no token is provided in config array in order to complete continuousphp/front#19